### PR TITLE
Switch rocksdb back to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -943,9 +943,9 @@ checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -2818,9 +2818,9 @@ checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ env_logger = "0.9.1"
 git-version = "0.3.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-rocksdb = "0.19.0"
+rocksdb = "0.18.0"
 serde_json = "1.0.85"
 uhlc = "0.5.1"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = [ "unstable" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,16 +347,7 @@ impl Storage for RocksdbStorage {
             Some(prefix) => prefix.as_str(),
             None => "",
         };
-        for (key, buf) in db
-            .prefix_iterator_cf(db.cf_handle(CF_DATA_INFO).unwrap(), db_prefix)
-            .filter_map(|r| match r {
-                Ok(x) => Some(x),
-                Err(e) => {
-                    warn!("Error iterating over RocksDB: {}", e);
-                    None
-                }
-            })
-        {
+        for (key, buf) in db.prefix_iterator_cf(db.cf_handle(CF_DATA_INFO).unwrap(), db_prefix) {
             let key_str = String::from_utf8_lossy(&key);
             let res_ke = match &self.config.strip_prefix {
                 Some(prefix) => prefix.join(key_str.as_ref()),
@@ -527,16 +518,7 @@ fn find_matching_kv(db: &DB, sub_selector: &str, results: &mut Vec<(String, Valu
     };
 
     // Iterate over DATA_INFO Column Family to avoid loading payloads possibly for nothing if not matching
-    for (key, buf) in db
-        .prefix_iterator_cf(db.cf_handle(CF_DATA_INFO).unwrap(), prefix)
-        .filter_map(|r| match r {
-            Ok(x) => Some(x),
-            Err(e) => {
-                warn!("Error iterating over RocksDB: {}", e);
-                None
-            }
-        })
-    {
+    for (key, buf) in db.prefix_iterator_cf(db.cf_handle(CF_DATA_INFO).unwrap(), prefix) {
         if let Ok(false) = decode_deleted_flag(&buf) {
             let key_str = String::from_utf8_lossy(&key);
             let key_expr = keyexpr::new(key_str.as_ref()).unwrap();
@@ -667,16 +649,7 @@ impl Timed for GarbageCollectionEvent {
         let cf_handle = db.cf_handle(CF_DATA_INFO).unwrap();
         let mut batch = WriteBatch::default();
         let mut count = 0;
-        for (key, buf) in db
-            .iterator_cf(cf_handle, IteratorMode::Start)
-            .filter_map(|r| match r {
-                Ok(x) => Some(x),
-                Err(e) => {
-                    warn!("Error iterating over RocksDB: {}", e);
-                    None
-                }
-            })
-        {
+        for (key, buf) in db.iterator_cf(cf_handle, IteratorMode::Start) {
             if let Ok(true) = decode_deleted_flag(&buf) {
                 if let Ok(timestamp) = decode_timestamp(&buf) {
                     if timestamp.get_time() < &time_limit {


### PR DESCRIPTION
The upgrade of `rocksdb` dependency to 0.19.0 caused the cross-builds to fail.
The reason is this new version requires **gcc 7** to build. 
But the cross build relies on :
 - [`jenoch/rust-cross`](https://hub.docker.com/repository/docker/jenoch/rust-cross) Docker images (customised to add clang12) which themselves relies on:
 - [`cross-rs 0.2.4`](https://github.com/cross-rs/cross/tree/v0.2.4/docker) images which themselves relies on:
 - Ubuntu 16.04 images which have **gcc 5** cross toolchain installed

No images of `cross-rs` based on Ubuntu 20.04 (using gcc 7) has been published yet.
Moreover, switching to more recent Ubuntu 20.04 would produce binaries requiring **libc 2.31**, vs. **libc 2.23** currently.

Therefore, we decided to switch back to **rocksdb 0.18.0** for the time being.  