### PR TITLE
README update: use zenohd --adminspace-permissions when required

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ You can setup storages either at zenoh router startup via a configuration file, 
 
 ### **Setup at runtime via `curl` commands on the admin space**
 
-  - Run the zenoh router:  
-    `zenohd`
+  - Run the zenoh router, with write permissions to its admin space:  
+    `zenohd --adminspace-permissions rw`
   - Add the "rocksdb" backend (the "zbackend_rocksdb" library will be loaded):  
    `curl -X PUT -H 'content-type:application/json' -d '{}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/rocksdb`
   - Add the "demo" storage using the "rocksdb" backend:  


### PR DESCRIPTION
Following https://github.com/eclipse-zenoh/zenoh/pull/351, update the README to make use of the new zenohd's `--adminspace-permissions rw` when creating Volume/Storage via the admin space.