### PR TITLE
fix: Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
       version: ${{ needs.tag.outputs.version }}
       repo: ${{ github.repository }}
       branch: ${{ needs.tag.outputs.branch }}
+      installation-test: false
     secrets: inherit
 
   homebrew:

--- a/Cross.toml
+++ b/Cross.toml
@@ -13,3 +13,6 @@ image = "jenoch/rust-cross:armv7-unknown-linux-gnueabihf"
 [target.aarch64-unknown-linux-gnu]
 image = "jenoch/rust-cross:aarch64-unknown-linux-gnu"
 
+[target.aarch64-unknown-linux-musl]
+image = "jenoch/rust-cross:aarch64-unknown-linux-musl"
+


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/actions/runs/8592540074.