### PR TITLE
feat: adding dynamic_plugin feature to enable the declare_plugin macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 stats = ["zenoh/stats"]
+dynamic_plugin = []
+default = ["dynamic_plugin"]
 
 [dependencies]
 async-std = "=1.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub(crate) enum OnClosure {
 }
 
 pub struct RocksDbBackend {}
+
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(RocksDbBackend);
 
 impl Plugin for RocksDbBackend {


### PR DESCRIPTION

Adding a `dynamic_plugin`  feature to feature-gate the `zenoh_plugin_trait::declare_plugin!` by default this feature is enabled.

Disabling it should allow static linking.