### PR TITLE
README: update zenohd instructions to load REST plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ You can setup storages either at zenoh router startup via a configuration file, 
 
 ### **Setup at runtime via `curl` commands on the admin space**
 
-  - Run the zenoh router, with write permissions to its admin space:  
-    `zenohd --adminspace-permissions rw`
+  - Run the zenoh router, with write permissions to its admin space and with the REST plugin:  
+    `zenohd --adminspace-permissions=rw --rest-http-port=8000`
   - Add the "rocksdb" backend (the "zenoh_backend_rocksdb" library will be loaded):  
    `curl -X PUT -H 'content-type:application/json' -d '{}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/rocksdb`
   - Add the "demo" storage using the "rocksdb" backend:  


### PR DESCRIPTION
Following https://github.com/eclipse-zenoh/zenoh/pull/1593 `zenohd` no longer loads the REST plugin by default.
This PR updates the READMEs to add `--rest-http-port=8000` to `zenohd` startup instructions.