### PR TITLE
fix: exclude target x86_64-pc-windows-gnu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
       repo: ${{ github.repository }}
       version: ${{ needs.tag.outputs.version }}
       branch: ${{ needs.tag.outputs.branch }}
+      exclude-builds: '[{ build: { target: "x86_64-pc-windows-gnu", os: "windows-2019" } }]'
       artifact-patterns: |
         ^libzenoh_backend_rocksdb\.(dylib|so)$
         ^zenoh_backend_rocksdb\.dll$


### PR DESCRIPTION
Target currently doesn't build with latest version of rust-rocksdb