### PR TITLE
Update adminspace keyexprs format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ You can setup storages either at zenoh router startup via a configuration file, 
 - Run the zenoh router, with write permissions to its admin space and with the REST plugin:  
   `zenohd --adminspace-permissions=rw --rest-http-port=8000`
 - Add the "rocksdb" backend (the "zenoh_backend_rocksdb" library will be loaded):  
- `curl -X PUT -H 'content-type:application/json' -d '{}' http://localhost:8000/@/router/local/config/plugins/storage_manager/volumes/rocksdb`
+ `curl -X PUT -H 'content-type:application/json' -d '{}' http://localhost:8000/@/local/router/config/plugins/storage_manager/volumes/rocksdb`
 - Add the "demo" storage using the "rocksdb" backend:  
- `curl -X PUT -H 'content-type:application/json' -d '{key_expr:"demo/example/**",strip_prefix:"demo/example",volume: {id: "rocksdb",dir: "example",create_db: true}}' http://localhost:8000/@/router/local/config/plugins/storage_manager/storages/demo`
+ `curl -X PUT -H 'content-type:application/json' -d '{key_expr:"demo/example/**",strip_prefix:"demo/example",volume: {id: "rocksdb",dir: "example",create_db: true}}' http://localhost:8000/@/local/router/config/plugins/storage_manager/storages/demo`
 
 ### **Tests using the REST API**
 


### PR DESCRIPTION
Format of keyexprs in README was not updated following the adminspace changes. This PR fixes it.