### PR TITLE
chore: update bump-deps-pattern for daily runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
       bump-deps-version: ${{ inputs.zenoh-version }}
-      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}
+      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '' }}
       bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/actions/runs/17027604088